### PR TITLE
修复action workflows和USB切换器无法在打包情况下正常显示图片的问题

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       # Check-out repository
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Python
         uses: actions/setup-python@v4
@@ -47,10 +47,11 @@ jobs:
           include-data-files: ./_cpyHook.cp39-win_amd64.pyd=_cpyHook.cp39-win_amd64.pyd,trans_cn.qm=trans_cn.qm,qtbase_cn.qm=qtbase_cn.qm
           include-qt-plugins: multimedia
           disable-console: true
+          enable-console: false
 
       # Uploads artifacts
       - name: "Upload Artifacts"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ runner.os }} Build
           path: |

--- a/Client/main.py
+++ b/Client/main.py
@@ -2650,14 +2650,14 @@ class MyMainWindow(QMainWindow, main_ui.Ui_MainWindow):
 
     def usb_switch_func(self, s):
         if s == 1:
-            self.usb_switch_dialog.graphics_label.setPixmap(QPixmap("Data/Images/kvmcard-2c.png"))
+            self.usb_switch_dialog.graphics_label.setPixmap(QPixmap(f"{PATH}/data/Images/kvmcard-2c.png"))
         elif s == 2:
-            self.usb_switch_dialog.graphics_label.setPixmap(QPixmap("Data/Images/kvmcard-discon.png"))
+            self.usb_switch_dialog.graphics_label.setPixmap(QPixmap(f"{PATH}/data/Images/kvmcard-discon.png"))
         elif s == 3:
-            self.usb_switch_dialog.graphics_label.setPixmap(QPixmap("Data/Images/kvmcard-2d.png"))
+            self.usb_switch_dialog.graphics_label.setPixmap(QPixmap(f"{PATH}/data/Images/kvmcard-2d.png"))
         else:
 
-            self.usb_switch_dialog.graphics_label.setPixmap(QPixmap("Data/Images/kvmcard-discon.png"))
+            self.usb_switch_dialog.graphics_label.setPixmap(QPixmap(f"{PATH}/data/Images/kvmcard-discon.png"))
 
             # read status
             reply = hid_def.hid_report([0x6F, 0, 3, 0], True)
@@ -2676,13 +2676,13 @@ class MyMainWindow(QMainWindow, main_ui.Ui_MainWindow):
                 # reply[5] //EN#
                 if reply[5] == 1:
                     self.usb_switch_dialog.radioButton_float.setChecked(True)
-                    self.usb_switch_dialog.graphics_label.setPixmap(QPixmap("Data/Images/kvmcard-discon.png"))
+                    self.usb_switch_dialog.graphics_label.setPixmap(QPixmap(f"{PATH}/data/Images/kvmcard-discon.png"))
                 elif reply[5] == 0 and reply[4] == 0:
                     self.usb_switch_dialog.radioButton_master.setChecked(True)
-                    self.usb_switch_dialog.graphics_label.setPixmap(QPixmap("Data/Images/kvmcard-2c.png"))
+                    self.usb_switch_dialog.graphics_label.setPixmap(QPixmap(f"{PATH}/data/Images/kvmcard-2c.png"))
                 elif reply[5] == 0 and reply[4] == 1:
                     self.usb_switch_dialog.radioButton_controlled.setChecked(True)
-                    self.usb_switch_dialog.graphics_label.setPixmap(QPixmap("Data/Images/kvmcard-2d.png"))
+                    self.usb_switch_dialog.graphics_label.setPixmap(QPixmap(f"{PATH}/data/Images/kvmcard-2d.png"))
                 else:
                     logger.debug("Function reply unknown error")
                     return


### PR DESCRIPTION
* 修复action的workflows，让其能正常走action在线编译。并且修复了原action无法关闭console的问题。
* 修复在打包单文件时，USB切换器界面无法正常显示图片的问题。（如下图）
修复前：
![3d9e999c7984da0699d7d1505f01be7e](https://github.com/user-attachments/assets/28da788f-15cd-42bc-9ab1-316df5f08a06)
修复后：
![b7e17c8eaa300aaa5185ebc944465ed6](https://github.com/user-attachments/assets/a1e49cdf-7e82-4fe8-b056-5f0f7a3ad14f)

